### PR TITLE
Make API base URL configurable

### DIFF
--- a/FilmeApp/App.js
+++ b/FilmeApp/App.js
@@ -1,8 +1,7 @@
 import AppNavigator from './Navigator';
-
+import { BASE_URL } from './config';
 
 export default function App() {
-    global.server = "localhost";
-    console.log(global.server);
+    console.log('Server URL:', BASE_URL);
     return (<AppNavigator/>);
 }

--- a/FilmeApp/app.config.js
+++ b/FilmeApp/app.config.js
@@ -1,0 +1,7 @@
+export default ({ config }) => ({
+  ...config,
+  extra: {
+    ...config.extra,
+    serverUrl: process.env.SERVER_URL || 'http://localhost:4000',
+  },
+});

--- a/FilmeApp/components/GraphPage.js
+++ b/FilmeApp/components/GraphPage.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { View, Text, Dimensions, TouchableOpacity, Modal, ScrollView } from 'react-native';
 import { BarChart } from 'react-native-chart-kit';
 import axios from 'axios';
+import { BASE_URL } from '../config';
 import { stylesGraph } from '../styles/style';
 
 export default class GraphPage extends React.Component {
@@ -24,7 +25,7 @@ export default class GraphPage extends React.Component {
 
   fetchAnalyticsData = () => {
     axios
-      .get(`http://${global.server}:4000/analytics/${this.state.contentObjectID}`)
+      .get(`${BASE_URL}/analytics/${this.state.contentObjectID}`)
       .then(response => {
         const { reactions } = response.data;
         this.setState({ datasets: reactions, isLoading: false });

--- a/FilmeApp/components/UploadPage.js
+++ b/FilmeApp/components/UploadPage.js
@@ -17,9 +17,10 @@ import NativeUploady, {
 import retryEnhancer, { useBatchRetry, useRetry, useRetryListener } from "@rpldy/retry-hooks";
 
 import axios from "axios";
+import { BASE_URL } from '../config';
 
 export default function UploadPage(props) {
-    const server = `http://${global.server}:4000/upload/`;
+    const server = `${BASE_URL}/upload/`;
     const [serverUploadDestUrl, setServerUploadDestUrl] = React.useState(server);
 
     const [linkToStorage, setLinkToStorage] = useState('');
@@ -175,7 +176,7 @@ export default function UploadPage(props) {
     }
 
     const handlePublish = () => {
-        axios.post(`http://${global.server}:4000/upload/`, {
+        axios.post(`${BASE_URL}/upload/`, {
             LinkToStorage:linkToStorage,
             LinkToPreviewImage:linkToPreviewImage,
             Title:title,

--- a/FilmeApp/config.js
+++ b/FilmeApp/config.js
@@ -1,0 +1,3 @@
+import Constants from 'expo-constants';
+
+export const BASE_URL = Constants.expoConfig?.extra?.serverUrl || 'http://localhost:4000';

--- a/FilmeApp/services/AuthService.js
+++ b/FilmeApp/services/AuthService.js
@@ -1,8 +1,9 @@
 import axios from 'axios';
+import { BASE_URL } from '../config';
 
 export function register(email, password, username) {
     return new Promise((resolve, reject) => {
-        axios.post(`http://${global.server}:4000/auth/register`, {
+        axios.post(`${BASE_URL}/auth/register`, {
             email: email, password: password, username: username
         }, {timeout: 15000})
             .then(response => {
@@ -17,7 +18,7 @@ export function register(email, password, username) {
 
 export function login(email, password) {
     return new Promise((resolve, reject) => {
-        axios.post(`http://${global.server}:4000/auth/login`, {email: email, password: password}, {timeout: 15000})
+        axios.post(`${BASE_URL}/auth/login`, {email: email, password: password}, {timeout: 15000})
             .then(response => {
                 resolve();
             })

--- a/FilmeApp/services/ExploreService.js
+++ b/FilmeApp/services/ExploreService.js
@@ -1,8 +1,9 @@
 import axios from 'axios';
+import { BASE_URL } from '../config';
 
 export function getUploads() {
     return new Promise((resolve, reject) => {
-        axios.get(`http://${global.server}:4000/exploreuploads`)
+        axios.get(`${BASE_URL}/exploreuploads`)
         .then(response => {
             resolve(response.data);
         })

--- a/FilmeApp/services/ProfileService.js
+++ b/FilmeApp/services/ProfileService.js
@@ -1,8 +1,9 @@
 import axios from 'axios';
+import { BASE_URL } from '../config';
 
 export function getCurrentUser(){
     return new Promise((resolve, reject) =>{
-        axios.get(`http://${global.server}:4000/profileuser`)
+        axios.get(`${BASE_URL}/profileuser`)
             .then(response => {
                 resolve(response.data);
             })
@@ -14,7 +15,7 @@ export function getCurrentUser(){
 
 export function getUsersUploads(){
     return new Promise((resolve, reject) => {
-        axios.get(`http://${global.server}:4000/uploads`)
+        axios.get(`${BASE_URL}/uploads`)
             .then(response => {
                 resolve(response.data);
             })

--- a/FilmeApp/services/ReactionsService.js
+++ b/FilmeApp/services/ReactionsService.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { BASE_URL } from '../config';
 
 export function sendReactions(uri, time, mediaId) {
     let formData = new FormData();
@@ -19,11 +20,11 @@ export function sendReactions(uri, time, mediaId) {
     formData.append('timestamp', "0" + minutes + ":" + seconds);
     formData.append('reactionTo', mediaId);
 
-    axios.get(`http://${global.server}:4000/profileuser`)
+    axios.get(`${BASE_URL}/profileuser`)
     .then(response => {
         formData.append('userReacting', response.data._id);
         
-        axios.post(`http://${global.server}:4000/react`, formData, {
+        axios.post(`${BASE_URL}/react`, formData, {
             headers: { 'Content-Type': 'multipart/form-data' },
         }).then(res => {
             console.log(res);


### PR DESCRIPTION
## Summary
- add Expo config file for environment variables
- add client config that exposes `BASE_URL`
- use `BASE_URL` in React Native app and services

## Testing
- `npm test --prefix Server` *(fails: Error: no test specified)*
- `npm test --prefix emotionRecognition` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_683f3f75218c832ba902e11d204cb859