### PR TITLE
Add search uploads route

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,9 @@ Add commentOnce a live reaction has been recorded, users will have the option to
 
 Upload contentUsers who wish to share their audio or video content can upload it to their profile on the FilmE application. The server will receive this data and make it available to users. Content that receives more live reactions from users will become more popular and will be ranked higher on the list for new users to discover.
 
-Display statistics of specific contentUsers can view the emotional response statistics for their content on the FilmE application. By selecting a specific piece of content, the user can request data on the emotions it elicited from viewers. The server will retrieve this information from the database and transmit it back to the user's device, where it will be displayed in the form of graphs and numerical data. 
+Search contentUsers can find specific uploads by providing a title keyword or tag. The server filters uploads using these parameters and returns the matching results.
+
+Display statistics of specific contentUsers can view the emotional response statistics for their content on the FilmE application. By selecting a specific piece of content, the user can request data on the emotions it elicited from viewers. The server will retrieve this information from the database and transmit it back to the user's device, where it will be displayed in the form of graphs and numerical data.
 
 8. **# References**
 

--- a/Server/routes/searchUploads.js
+++ b/Server/routes/searchUploads.js
@@ -1,0 +1,24 @@
+import express from 'express';
+import Upload from '../dbSchemas/upload.js';
+
+const router = express.Router();
+
+router.get('/searchuploads', async (req, res) => {
+    const { title, tag } = req.query;
+    const filters = {};
+    if (title) {
+        filters.Title = { $regex: title, $options: 'i' };
+    }
+    if (tag) {
+        filters.Tags = { $in: [tag] };
+    }
+    try {
+        const uploads = await Upload.find(filters).populate({ path: 'Uploader', model: 'Users' });
+        res.json(uploads);
+    } catch (error) {
+        console.log(error);
+        res.status(500).json({ error: 'Error searching uploads' });
+    }
+});
+
+export { router as searchUploads };

--- a/Server/server.js
+++ b/Server/server.js
@@ -6,6 +6,7 @@ import {connectToMongo} from './dbUtils.js'
 import { getUploads } from './routes/getUploads.js';
 import { getUsers } from './routes/getUsers.js';
 import { getExploreUploads } from './routes/getExploreUploads.js'
+import { searchUploads } from './routes/searchUploads.js';
 import {reactRoute} from "./routes/reaction.js";
 import {reactionsAnalytics} from "./routes/reactionsAnalytics.js";
 
@@ -17,8 +18,10 @@ connectToMongo();
 app.use('/upload', uploadRoute);
 
 app.use('/auth', authRoute);
-  
+
 app.get('/uploads', getUploads);
+
+app.get('/searchuploads', searchUploads);
 
 app.get('/profileuser', getUsers);
 

--- a/Server/test/searchUploads.test.js
+++ b/Server/test/searchUploads.test.js
@@ -1,0 +1,33 @@
+import request from 'supertest';
+import express from 'express';
+
+jest.mock('../dbSchemas/upload.js', () => ({
+  find: jest.fn()
+}));
+
+import Upload from '../dbSchemas/upload.js';
+import { searchUploads } from '../routes/searchUploads.js';
+
+const createApp = () => {
+  const app = express();
+  app.use('/searchuploads', searchUploads);
+  return app;
+};
+
+describe('GET /searchuploads', () => {
+  it('returns results on success', async () => {
+    Upload.find.mockResolvedValue([{ Title: 'song' }]);
+    const app = createApp();
+    const res = await request(app).get('/searchuploads').query({ title: 'song' });
+    expect(Upload.find).toHaveBeenCalled();
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual([{ Title: 'song' }]);
+  });
+
+  it('returns 500 on error', async () => {
+    Upload.find.mockRejectedValue(new Error('fail'));
+    const app = createApp();
+    const res = await request(app).get('/searchuploads').query({ title: 'bad' });
+    expect(res.statusCode).toBe(500);
+  });
+});


### PR DESCRIPTION
## Summary
- add a new `/searchuploads` API route for filtering uploads by title or tag
- hook the new route into the Express server
- describe the search capability in the README
- test the route with Jest

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_683f44a17e00832bb8a173231160539a